### PR TITLE
fix: la-116 Slug Field API Error Display

### DIFF
--- a/src/features/auth/components/InstitutionForm.tsx
+++ b/src/features/auth/components/InstitutionForm.tsx
@@ -89,29 +89,21 @@ const InstitutionForm = () => {
             labelClassName="text-sm text-gray-600 text-left"
             fieldClassName="flex flex-col space-y-2"
           />
+          
         </div>
 
-        <div className="flex flex-col">
-          <label className="text-sm text-gray-600 text-left mb-1">
-            Organisation Slug
-          </label>
-          <div className="flex items-center">
-            <input
-              {...register('slug')}
-              type="text"
-              placeholder="e.g. ivy-college"
-              className={`rounded-3xl border h-11 px-4 w-full focus:outline-none focus:border-blue-600 focus:ring-0 ${
-                errors.slug ? 'border-red-500' : 'border-gray-300'
-              }`}
-            />
-            <span className="ml-2 text-gray-500 whitespace-nowrap">.lumaai.com</span>
-          </div>
-          {errors.slug && (
-            <p className="text-left mt-1 text-sm text-red-600">
-              {errors.slug.message}
-            </p>
+          <Input
+          id="slug"
+          label="Organisation Slug"
+          placeholder="e.g. ivy-college"
+          {...register('slug')}
+          error={errors.slug?.message}
+          addonElement={() => (
+            <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 whitespace-nowrap pointer-events-none">
+              .lumaai.com
+            </span>
           )}
-        </div>
+        />
 
         <div className="flex gap-2 md:gap-4 mt-8">
           <Button


### PR DESCRIPTION
Summary
This PR adds the ability to display API errors directly under the slug field in the institution form, providing better user experience by showing field-specific validation errors from the backend.

Problem
Previously, all API errors from the institution creation endpoint were only displayed as global toast messages. This meant that slug-specific validation errors (like "slug already exists") appeared as generic toasts instead of being clearly associated with the slug input field.

Solution
Implemented field-specific error handling that:

Checks for result.meta?.field === 'slug' in API responses
Uses setError('slug', { message }) to display errors directly under the slug input
Maintains existing global toast behavior for non-field errors
Follows the same pattern used in the signup form

## Test
<img width="501" height="123" alt="Screenshot 2025-08-02 at 19 57 02" src="https://github.com/user-attachments/assets/4bed5e1e-7fd5-4c21-8ae3-7d4dcca30417" />

