### PR TITLE
[feat]LA-122 Add Email Validation When Sending Verification Code

### DIFF
--- a/src/features/auth/components/SignUpForm.tsx
+++ b/src/features/auth/components/SignUpForm.tsx
@@ -42,6 +42,7 @@ const SignUpForm = ({
     setError,
     setValue,
     clearErrors,
+    trigger, 
     formState: { errors, isSubmitting },
   } = useForm<z.infer<typeof signupSchema>>({
     resolver: zodResolver(signupSchema),
@@ -87,7 +88,16 @@ const SignUpForm = ({
   }, [verificationCode, clearErrors]);
 
   const handleSendCode = async () => {
-    if (!email || !canSend) return;
+    if (!email) {
+      setError('email', {
+        message: 'Please enter your email address',
+      });
+      return;
+    }
+
+    const isEmailValid = await trigger('email');
+    
+    if (!isEmailValid || !canSend) return;
 
     clearErrors('verificationCode');
 


### PR DESCRIPTION
Solution:

Added email validation before sending verification code
Used trigger('email') to validate email format using existing Zod schema rules
Added explicit error handling for empty email fields
Improved user feedback for invalid email scenarios

Changes:

Added trigger method from useForm hook
Enhanced handleSendCode function with proper email validation
Now shows appropriate error messages for empty or invalid emails