### PR TITLE
[fix]LA-125 Restrict Password Special Characters to Allowed Set Only

### DIFF
--- a/src/features/auth/schemas.ts
+++ b/src/features/auth/schemas.ts
@@ -65,13 +65,7 @@ export const teacherSignupSchema = z
       .string()
       .min(1, 'Please enter your email address')
       .email('Sorry, please type a valid email'),
-    password: z
-      .string()
-      .min(1, 'Please enter your password')
-      .regex(
-        /^(?=.*[A-Z])(?=.*[a-z])(?=.*\d)(?=.*[^A-Za-z0-9]).{8,20}$/,
-        'Password must be 8–20 characters and contain at least one uppercase letter, lowercase letter, number and special character'
-      ),
+    password: newPasswordSchema,
     confirmPassword: z.string().min(1, 'Please confirm your password'),
     agreeTerms: z.literal(true, {
       errorMap: () => ({ message: 'You must agree to the terms to continue.' }),

--- a/src/schema/validation.ts
+++ b/src/schema/validation.ts
@@ -23,7 +23,8 @@ export const newPasswordSchema = z
       /[A-Z]/.test(pwd) &&
       /[a-z]/.test(pwd) &&
       /[0-9]/.test(pwd) &&
-      /[^A-Za-z0-9]/.test(pwd),
+      /[!@#$%^&*]/.test(pwd) &&
+      /^[A-Za-z0-9!@#$%^&*]+$/.test(pwd),
     {
       message:
         'Password must be 8-20 characters and contain at least one uppercase letter, lowercase letter, number and special character from the following !@#$%^&*',


### PR DESCRIPTION
### Problem
The current password validation schema had inconsistent behavior:
- Error message specified only `!@#$%^&*` special characters are allowed
- Validation logic accepted ANY special character (e.g., `()`, `_`, `+=`, `<>`)
- Backend validation was working correctly, but frontend validation was permissive

### Solution
Updated the password schema validation to:
1. **Check for required special characters**: Changed `/[^A-Za-z0-9]/` to `/[!@#$%^&*]/` to ensure at least one allowed special character is present
2. **Restrict to allowed characters only**: Added `/^[A-Za-z0-9!@#$%^&*]+$/` to prevent any unauthorized characters