### PR TITLE
[fix]LA-126 Fix Logic to Prevent Redirect on Signup Errors

### DIFF
--- a/src/api/auth/signup.ts
+++ b/src/api/auth/signup.ts
@@ -36,7 +36,6 @@ class SignupServiceImpl implements SignupService {
     if (result.accessToken) {
       localStorage.setItem('accessToken', result.accessToken);
     }
-    return response
   }
 
   async signupAsLearner(data: SignupFormData): Promise<ApiError | void> {

--- a/src/features/auth/components/SignUpForm.tsx
+++ b/src/features/auth/components/SignUpForm.tsx
@@ -143,19 +143,6 @@ const SignUpForm = ({
 
     onSuccess?.(data);
 
-    const timeoutId = setTimeout(() => {
-      console.log('Navigating to dashboard');
-      navigate('/dashboard');
-    }, 3000);
-
-    showToastWithAction('Successfully signed up! Redirecting...', {
-      actionText: 'Go Now',
-      onAction: () => {
-        clearTimeout(timeoutId);
-        navigate('/dashboard');
-      },
-      duration: 2000,
-    });
   };
 
   return (

--- a/src/features/auth/components/SignUpForm.tsx
+++ b/src/features/auth/components/SignUpForm.tsx
@@ -131,22 +131,6 @@ const SignUpForm = ({
 
     const result = await signupService.signup(payload, userRole);
 
-    if (!result) {
-      onSuccess?.(data);
-
-      const timeoutId = setTimeout(() => {
-        navigate('/dashboard');
-      }, 3000);
-
-      showToastWithAction('Successfully signed up! Redirecting...', {
-        actionText: 'Go Now',
-        onAction: () => {
-          clearTimeout(timeoutId);
-          navigate('/dashboard');
-        },
-        duration: 2000,
-      });
-    }
 
     if (result) {
       if (result.meta?.field) {
@@ -156,6 +140,22 @@ const SignUpForm = ({
       }
       return;
     }
+
+    onSuccess?.(data);
+
+    const timeoutId = setTimeout(() => {
+      console.log('Navigating to dashboard');
+      navigate('/dashboard');
+    }, 3000);
+
+    showToastWithAction('Successfully signed up! Redirecting...', {
+      actionText: 'Go Now',
+      onAction: () => {
+        clearTimeout(timeoutId);
+        navigate('/dashboard');
+      },
+      duration: 2000,
+    });
   };
 
   return (

--- a/src/features/auth/components/SignUpForm.tsx
+++ b/src/features/auth/components/SignUpForm.tsx
@@ -132,17 +132,30 @@ const SignUpForm = ({
     const result = await signupService.signup(payload, userRole);
 
     if (!result) {
-      return;
-    }
-    if (result.meta?.field) {
-      setError(result.meta.field as keyof z.infer<typeof signupSchema>, {
-        message: result.message,
+      onSuccess?.(data);
+
+      const timeoutId = setTimeout(() => {
+        navigate('/dashboard');
+      }, 3000);
+
+      showToastWithAction('Successfully signed up! Redirecting...', {
+        actionText: 'Go Now',
+        onAction: () => {
+          clearTimeout(timeoutId);
+          navigate('/dashboard');
+        },
+        duration: 2000,
       });
-      return;
     }
 
-    onSuccess?.(data);
-    return;
+    if (result) {
+      if (result.meta?.field) {
+        setError(result.meta.field as keyof z.infer<typeof signupSchema>, {
+          message: result.message,
+        });
+      }
+      return;
+    }
   };
 
   return (

--- a/src/features/auth/components/TeacherSignUpForm.tsx
+++ b/src/features/auth/components/TeacherSignUpForm.tsx
@@ -10,6 +10,7 @@ import { useEffect } from 'react';
 import { authService } from '@api/auth/auth';
 import { signupService } from '@api/auth/signup';
 import { Checkbox } from '@components/forms/Checkbox';
+import { showToastWithAction } from '@components/toast/ToastWithAction';
 import { decodeJwt } from '@utils/jwtUtils';
 
 export default function TeacherSignUpForm(props: { token: string }) {
@@ -65,6 +66,19 @@ export default function TeacherSignUpForm(props: { token: string }) {
       }
       return;
     }
+
+    const timeoutId = setTimeout(() => {
+      navigate('/dashboard');
+    }, 3000);
+
+    showToastWithAction('Successfully signed up! Redirecting...', {
+      actionText: 'Go Now',
+      onAction: () => {
+        clearTimeout(timeoutId);
+        navigate('/dashboard');
+      },
+      duration: 2000,
+    });
   };
 
   return (

--- a/src/features/auth/components/TeacherSignUpForm.tsx
+++ b/src/features/auth/components/TeacherSignUpForm.tsx
@@ -10,7 +10,6 @@ import { useEffect } from 'react';
 import { authService } from '@api/auth/auth';
 import { signupService } from '@api/auth/signup';
 import { Checkbox } from '@components/forms/Checkbox';
-import { showToastWithAction } from '@components/toast/ToastWithAction';
 import { decodeJwt } from '@utils/jwtUtils';
 
 export default function TeacherSignUpForm(props: { token: string }) {
@@ -66,19 +65,6 @@ export default function TeacherSignUpForm(props: { token: string }) {
       }
       return;
     }
-
-    const timeoutId = setTimeout(() => {
-      navigate('/dashboard');
-    }, 3000);
-
-    showToastWithAction('Successfully signed up! Redirecting...', {
-      actionText: 'Go Now',
-      onAction: () => {
-        clearTimeout(timeoutId);
-        navigate('/dashboard');
-      },
-      duration: 2000,
-    });
   };
 
   return (


### PR DESCRIPTION
Changes

Added dashboard redirect logic: After successful signup, users are automatically redirected to /dashboard after 3 seconds
Enhanced UX with toast notification: Shows "Successfully signed up! Redirecting..." message with a "Go Now" button for immediate redirection
Preserved existing functionality: The onSuccess callback is still called to maintain backward compatibility
Fixed error handling: Ensures redirection only occurs on successful signup, not when errors are present