### PR TITLE
[Bugfix]: LA-128 hide verificationCode input if has token

### DIFF
--- a/src/app/auth/signup/admin/page.tsx
+++ b/src/app/auth/signup/admin/page.tsx
@@ -1,13 +1,13 @@
-import logo from '@assets/logo.svg';
 import rightLogo from '@assets/decorative_graphic.png';
+import logo from '@assets/logo.svg';
+import RedirectNoticePage from '@components/layout/RedirectNoticePage';
+import { showToastWithAction } from '@components/toast/ToastWithAction';
 import SignUpForm from '@features/auth/components/SignUpForm';
 import { UserRole } from '@features/auth/types';
-import { useNavigate } from 'react-router-dom';
-import { filterSignupForm } from '@utils/filterSignupForm';
-import { showToastWithAction } from '@components/toast/ToastWithAction';
 import { useQueryToken } from '@hooks/useQueryToken';
 import { isMainDomain } from '@utils/domainUtils';
-import RedirectNoticePage from '@components/layout/RedirectNoticePage';
+import { filterSignupForm } from '@utils/filterSignupForm';
+import { useNavigate } from 'react-router-dom';
 
 const AdminSignUpPage = () => {
   const navigate = useNavigate();
@@ -67,7 +67,7 @@ const AdminSignUpPage = () => {
 
         <section className="w-full max-w-sm sm:max-w-md lg:max-w-md">
           <div className="w-full">
-            <SignUpForm userRole={UserRole.ADMIN} token={token} onSuccess={onSuccess} />
+            <SignUpForm userRole={UserRole.ADMIN} token={token} onSuccess={onSuccess} hideVerificationCode={!!token} />
           </div>
         </section>
       </main>

--- a/src/app/auth/signup/learner/page.tsx
+++ b/src/app/auth/signup/learner/page.tsx
@@ -1,10 +1,10 @@
-import logo from '@assets/logo.svg';
 import leftLogo from '@assets/decorative_graphic.png';
+import logo from '@assets/logo.svg';
+import { showToastWithAction } from '@components/toast/ToastWithAction';
 import SignUpForm from '@features/auth/components/SignUpForm';
 import { UserRole } from '@features/auth/types';
-import { useNavigate } from 'react-router-dom';
-import { showToastWithAction } from '@components/toast/ToastWithAction';
 import { useQueryToken } from '@hooks/useQueryToken';
+import { useNavigate } from 'react-router-dom';
 
 const LearnerSignUpPage = () => {
   const navigate = useNavigate();
@@ -59,6 +59,7 @@ const LearnerSignUpPage = () => {
               token={token}
               theme="learner"
               onSuccess={onSuccess}
+              hideVerificationCode={!!token}
             />
           </div>
         </section>

--- a/src/features/auth/components/SignUpForm.tsx
+++ b/src/features/auth/components/SignUpForm.tsx
@@ -127,7 +127,7 @@ const SignUpForm = ({
       username: data.username,
       email: data.email,
       password: data.password,
-      verifyValue: data.verificationCode,
+      verifyValue: data.verificationCode?.trim() ? data.verificationCode : (token ?? ''),
       termsAccepted: data.termsAccepted,
       token: data.token,
     };

--- a/src/features/auth/components/SignUpForm.tsx
+++ b/src/features/auth/components/SignUpForm.tsx
@@ -1,27 +1,28 @@
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { signupSchema } from '../schemas';
-import { z } from 'zod';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { useSendCode } from '@features/auth/hooks/useSendCode';
+import { authService } from '@api/auth/auth';
+import { signupService } from '@api/auth/signup';
+import { Button } from '@components/buttons/Button';
+import { Checkbox } from '@components/forms/Checkbox';
 import { Input } from '@components/forms/Input';
 import { PasswordInput } from '@components/forms/PasswordInput';
-import { Button } from '@components/buttons/Button';
 import { VerificationCodeInput } from '@components/forms/VerificationCodeInput';
 import { showToastWithAction } from '@components/toast/ToastWithAction';
+import { useSendCode } from '@features/auth/hooks/useSendCode';
 import { UserRole } from '@features/auth/types';
-import { Checkbox } from '@components/forms/Checkbox';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useFormTheme, type ThemeType } from '@styles/formThemeStyles';
-import { signupService } from '@api/auth/signup';
-import { useEffect } from 'react';
 import { decodeJwt } from '@utils/jwtUtils';
-import { authService } from '@api/auth/auth';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { z } from 'zod';
+import { signupSchema } from '../schemas';
 
 interface SignUpFormProps {
   userRole?: UserRole;
   onSuccess?: (data?: any) => void;
   theme?: ThemeType;
   token?: string;
+  hideVerificationCode?: boolean;
 }
 
 const SignUpForm = ({
@@ -29,6 +30,7 @@ const SignUpForm = ({
   onSuccess,
   theme = 'default',
   token,
+  hideVerificationCode = false,
 }: SignUpFormProps) => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -53,6 +55,7 @@ const SignUpForm = ({
   useEffect(() => {
     const checkIfActiveUser = async () => {
       if (!token) {
+
         return;
       }
       const result = await authService.isActiveUser(token ?? '');
@@ -159,20 +162,22 @@ const SignUpForm = ({
         isDisabled={!!token}
       />
 
-      <VerificationCodeInput
-        id="verificationCode"
-        label="Verification Code"
-        placeholder="Enter the 6-digit code"
-        buttonText={countDown > 0 ? `Resend in ${countDown}s` : 'Send'}
-        onButtonClick={handleSendCode}
-        isButtonDisabled={!canSend}
-        {...register('verificationCode')}
-        error={errors.verificationCode?.message}
-        inputClassName={themeStyles.inputClassName}
-        labelClassName={themeStyles.labelClassName}
-        buttonClassName={themeStyles.verificationButtonClass}
-      />
-
+      {!hideVerificationCode && (
+        <VerificationCodeInput
+          id="verificationCode"
+          label="Verification Code"
+          placeholder="Enter the 6-digit code"
+          buttonText={countDown > 0 ? `Resend in ${countDown}s` : 'Send'}
+          onButtonClick={handleSendCode}
+          isButtonDisabled={!canSend}
+          {...register('verificationCode')}
+          error={errors.verificationCode?.message}
+          inputClassName={themeStyles.inputClassName}
+          labelClassName={themeStyles.labelClassName}
+          buttonClassName={themeStyles.verificationButtonClass}
+          />
+        )}
+        
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <Input
           id="firstName"

--- a/src/features/auth/schemas.ts
+++ b/src/features/auth/schemas.ts
@@ -30,6 +30,18 @@ export const signupSchema = z
   .refine((data) => data.password === data.confirmPassword, {
     message: 'Passwords do not match',
     path: ['confirmPassword'],
+  })
+  .superRefine((data, ctx) => {
+    // if no token ，verificationCode mush 6
+    if (!data.token) {
+      if (!data.verificationCode || !/^\d{6}$/.test(data.verificationCode)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Verification code must be 6 digits',
+          path: ['verificationCode'],
+        });
+      }
+    }
   });
 
 export const institutionSchema = z.object({

--- a/src/features/auth/schemas.ts
+++ b/src/features/auth/schemas.ts
@@ -20,7 +20,7 @@ export const signupSchema = z
     token: z.string().optional(),
     username: usernameSchema,
     email: emailSchema,
-    verificationCode: verificationCodeSchema,
+    verificationCode: z.string().optional().default(''),
     password: newPasswordSchema,
     confirmPassword: z.string().min(1, 'Please confirm your password'),
     termsAccepted: z

--- a/src/schema/validation.ts
+++ b/src/schema/validation.ts
@@ -7,13 +7,7 @@ export const emailSchema = z
   .min(1, 'Please enter your email address')
   .email('Please type a valid email');
 
-export const verificationCodeSchema = z
-  .string()
-  .optional()
-  .default('')
-  .refine(val => val === '' || (/^\d{6}$/.test(val)), {
-    message: 'Verification code must be 6 digits',
-  });
+export const verificationCodeSchema = z.string().optional().default('')
 
 export const newPasswordSchema = z
   .string()

--- a/src/schema/validation.ts
+++ b/src/schema/validation.ts
@@ -9,9 +9,11 @@ export const emailSchema = z
 
 export const verificationCodeSchema = z
   .string()
-  .min(1, 'Please enter the verification code')
-  .length(6, 'Verification code must be 6 digits')
-  .regex(/^\d{6}$/, 'Verification code must contain only digits');
+  .optional()
+  .default('')
+  .refine(val => val === '' || (/^\d{6}$/.test(val)), {
+    message: 'Verification code must be 6 digits',
+  });
 
 export const newPasswordSchema = z
   .string()

--- a/src/schema/validation.ts
+++ b/src/schema/validation.ts
@@ -7,7 +7,11 @@ export const emailSchema = z
   .min(1, 'Please enter your email address')
   .email('Please type a valid email');
 
-export const verificationCodeSchema = z.string().optional().default('')
+export const verificationCodeSchema = z
+  .string()
+  .min(1, 'Please enter the verification code')
+  .length(6, 'Verification code must be 6 digits')
+  .regex(/^\d{6}$/, 'Verification code must contain only digits');
 
 export const newPasswordSchema = z
   .string()


### PR DESCRIPTION
## Change
1. Hide verificationCode input when user signup via invitation link (has token).
2. Fix verificationCode as optional for onSuccess()
3. if no verificationCode pass token to backend avoid null value.

## Test
 1. admin signup url show verificationCode input
<img width="713" height="601" alt="Screenshot 2025-08-07 at 22 17 09" src="https://github.com/user-attachments/assets/9386e830-4387-411c-b5fa-7b1e1214d0f8" />
4. Hide when invitation
<img width="1049" height="569" alt="Screenshot 2025-08-07 at 22 16 33" src="https://github.com/user-attachments/assets/5741bc99-55c5-4fd5-b9d7-9d6f62ce2494" />

5. learner signup url show verificationCode input
<img width="1391" height="603" alt="Screenshot 2025-08-07 at 22 16 53" src="https://github.com/user-attachments/assets/0538d483-a356-4f16-8c28-1c3e811deca1" />
Hide
<img width="1008" height="604" alt="Screenshot 2025-08-07 at 22 16 17" src="https://github.com/user-attachments/assets/48c09a29-b476-4f4c-b7ef-d14b70a0a091" />

